### PR TITLE
Spanish translations reviewed

### DIFF
--- a/app/src/main/java/org/walkersguide/android/data/object_with_id/point/Intersection.java
+++ b/app/src/main/java/org/walkersguide/android/data/object_with_id/point/Intersection.java
@@ -113,11 +113,9 @@ public class Intersection extends Point implements Serializable {
     }
 
     public String formatNumberOfCrossingsNearby() {
-        return String.format(
-                GlobalInstance.getStringResource(R.string.intersectionNumberOfCrossingsNearby),
-                GlobalInstance.getPluralResource(
-                    R.plurals.crossing,
-                    hasPedestrianCrossings() ? this.pedestrianCrossingList.size() : 0));
+        return GlobalInstance.getPluralResource(
+                R.plurals.intersectionNumberOfCrossingsNearby,
+                hasPedestrianCrossings() ? this.pedestrianCrossingList.size() : 0);
     }
 
     @Override public String toString() {

--- a/app/src/main/java/org/walkersguide/android/ui/adapter/PinnedObjectsAdapter.java
+++ b/app/src/main/java/org/walkersguide/android/ui/adapter/PinnedObjectsAdapter.java
@@ -71,8 +71,10 @@ public class PinnedObjectsAdapter extends BaseExpandableListAdapter {
         String quantityString = null;
         switch (groupPosition) {
             case ID_PROFILES:
-                quantityString = GlobalInstance.getPluralResource(
-                        R.plurals.profile, profileList.size());
+                quantityString = String.format(
+                        GlobalInstance.getPluralText(R.plurals.labelSomethingPinned, profileList.size()),
+                        GlobalInstance.getPluralResource(R.plurals.profile, profileList.size()));
+
                 holder.buttonAdd.setContentDescription(
                         context.getResources().getString(R.string.buttonAddPinnedProfile));
                 holder.buttonAdd.setOnClickListener(new View.OnClickListener() {
@@ -83,8 +85,9 @@ public class PinnedObjectsAdapter extends BaseExpandableListAdapter {
                 break;
 
             case ID_OBJECTS:
-                quantityString = GlobalInstance.getPluralResource(
-                        StaticProfile.pinnedObjectsWithId().getPluralResId(), objectList.size());
+                quantityString = String.format(
+                        GlobalInstance.getPluralText(R.plurals.labelSomethingPinned, objectList.size()),
+                        GlobalInstance.getPluralResource(StaticProfile.pinnedObjectsWithId().getPluralResId(), objectList.size()));
                 holder.buttonAdd.setContentDescription(
                         context.getResources().getString(R.string.buttonAddPinnedPointOrRoute));
                 holder.buttonAdd.setOnClickListener(new View.OnClickListener() {
@@ -96,11 +99,7 @@ public class PinnedObjectsAdapter extends BaseExpandableListAdapter {
         }
 
         if (quantityString != null) {
-            holder.labelHeading.setText(
-                    String.format(
-                        context.getResources().getString(R.string.labelSomethingPinned),
-                        quantityString)
-                    );
+            holder.labelHeading.setText(quantityString);
             holder.buttonAdd.setVisibility(View.VISIBLE);
         }
         return convertView;

--- a/app/src/main/java/org/walkersguide/android/util/GlobalInstance.java
+++ b/app/src/main/java/org/walkersguide/android/util/GlobalInstance.java
@@ -68,6 +68,10 @@ public class GlobalInstance extends Application {
         return getContext().getResources().getQuantityString(resourceId, number, number);
     }
 
+    public static String getPluralText(int resourceId, int number) {
+        return getContext().getResources().getQuantityText(resourceId, number).toString();
+    }
+
 
     /**
      * session id

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -229,7 +229,6 @@
     <string name="menuItemClearPinnedObjectsOnlyProfiles">Nur Profile</string>
     <string name="menuItemClearPinnedObjectsOnlyPointsAndRoutes">Nur Punkte und Routen</string>
     <string name="menuItemClearPinnedObjectsBoth">Alles zurücksetzen</string>
-    <string name="labelSomethingPinned">%1$s angeheftet</string>
     <string name="groupNameProfiles">Profile</string>
     <string name="buttonAddPinnedProfile">Profil anheften</string>
     <string name="groupNamePointsAndRoutes">Punkte und Routen</string>
@@ -876,7 +875,6 @@
 
     <!-- intersection point -->
     <string name="intersectionNumberOfStreets">Kreuzung mit %1$s</string>
-    <string name="intersectionNumberOfCrossingsNearby">%1$s in der Nähe</string>
 
     <!-- PedestrianCrossing -->
     <!-- details in toString -->
@@ -1350,6 +1348,13 @@
         <item quantity="other">%d Querungen</item>
     </plurals>
 
+    <!-- format example: 2 crossings nearby -->
+    <plurals
+        name="intersectionNumberOfCrossingsNearby">
+        <item quantity="one">1 Querung in der Nähe</item>
+        <item quantity="other">%d Querungen in der Nähe</item>
+    </plurals>
+
     <plurals
         name="entrance">
         <item quantity="one">1 Eingang</item>
@@ -1420,6 +1425,12 @@
         name="poiCategorySelected">
         <item quantity="one">1 Punktkategorie ausgewählt</item>
         <item quantity="other">%d Punktkategorien ausgewählt</item>
+    </plurals>
+
+    <plurals
+        name="labelSomethingPinned">
+        <item quantity="one">%1$s angeheftet</item>
+        <item quantity="other">%1$s angeheftet</item>
     </plurals>
 
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1252,120 +1252,140 @@
     <plurals
         name="departure">
         <item quantity="one">1 salida</item>
+        <item quantity="many">%d de salidas</item>
         <item quantity="other">%d salidas</item>
     </plurals>
 
     <plurals
         name="hourShort">
         <item quantity="one">1 h</item>
+        <item quantity="many">%d h</item>
         <item quantity="other">%d h</item>
     </plurals>
 
     <plurals
         name="hourLong">
         <item quantity="one">una hora</item>
+        <item quantity="many">%d de horas</item>
         <item quantity="other">%d horas</item>
     </plurals>
 
     <plurals
         name="minuteShort">
         <item quantity="one">1 min</item>
+        <item quantity="many">%d de min</item>
         <item quantity="other">%d min</item>
     </plurals>
 
     <plurals
         name="minuteLong">
         <item quantity="one">un minuto</item>
+        <item quantity="many">%d de minutos</item>
         <item quantity="other">%d minutos</item>
     </plurals>
 
     <plurals
         name="meter">
         <item quantity="one">1 metro</item>
+        <item quantity="many">%d de metros</item>
         <item quantity="other">%d metros</item>
     </plurals>
 
     <plurals
         name="meterFloat">
         <item quantity="one">1.0 metro</item>
+        <item quantity="many">%1$.1f de metros</item>
         <item quantity="other">%1$.1f metros</item>
     </plurals>
 
     <plurals
         name="meterShort">
         <item quantity="one">1 m</item>
+        <item quantity="many">%d m</item>
         <item quantity="other">%d m</item>
     </plurals>
 
     <plurals
         name="inMeters">
         <item quantity="one">En 1 metro</item>
+        <item quantity="many">En %d de metros</item>
         <item quantity="other">En %d metros</item>
     </plurals>
 
     <plurals
         name="result">
         <item quantity="one">1 resultado</item>
+        <item quantity="many">%d de resultados</item>
         <item quantity="other">%d resultados</item>
     </plurals>
 
     <plurals
         name="satellite">
         <item quantity="one">1 satélite</item>
+        <item quantity="many">%d de satélites</item>
         <item quantity="other">%d satélites</item>
     </plurals>
 
     <plurals
         name="object">
         <item quantity="one">1 objeto</item>
+        <item quantity="many">%d de objetos</item>
         <item quantity="other">%d objetos</item>
     </plurals>
 
     <plurals
         name="point">
         <item quantity="one">1 punto</item>
+        <item quantity="many">%d de puntos</item>
         <item quantity="other">%d puntos</item>
     </plurals>
 
     <plurals
         name="manuallyAddedPoint">
         <item quantity="one">1 punto añadido manualmente</item>
+        <item quantity="many">%d de puntos añadidos manualmente</item>
         <item quantity="other">%d puntos añadidos manualmente</item>
     </plurals>
 
     <plurals
         name="trackedPoint">
         <item quantity="one">1 punto seguido</item>
+        <item quantity="many">%d de puntos seguidos</item>
         <item quantity="other">%d puntos seguidos</item>
     </plurals>
 
     <plurals
         name="route">
         <item quantity="one">1 ruta</item>
+        <item quantity="many">%d de rutas</item>
         <item quantity="other">%d rutas</item>
     </plurals>
 
     <plurals
         name="pointAndRoute">
         <item quantity="one">1 punto o ruta</item>
+        <item quantity="many">%d de puntos y rutas</item>
         <item quantity="other">%d puntos y rutas</item>
     </plurals>
 
     <plurals
         name="recordedRoute">
         <item quantity="one">1 ruta grabada</item>
+        <item quantity="many">%d de rutas grabadas</item>
         <item quantity="other">%d rutas grabadas</item>
     </plurals>
 
     <plurals
         name="way">
         <item quantity="one">1 vía</item>
+        <item quantity="many">%d de vías</item>
         <item quantity="other">%d vías</item>
     </plurals>
 
     <plurals
         name="crossing">
         <item quantity="one">1 cruce</item>
+        <item quantity="many">%d de cruces</item>
         <item quantity="other">%d cruces</item>
     </plurals>
 
@@ -1373,84 +1393,98 @@
     <plurals
         name="intersectionNumberOfCrossingsNearby">
         <item quantity="one">1 cruce cercano</item>
+        <item quantity="many">%d de cruces cercanos</item>
         <item quantity="other">%d cruces cercanos</item>
     </plurals>
 
     <plurals
         name="entrance">
         <item quantity="one">1 entrada</item>
+        <item quantity="many">%d de entradas</item>
         <item quantity="other">%d entradas</item>
     </plurals>
 
     <plurals
         name="intersection">
         <item quantity="one">1 intersección</item>
+        <item quantity="many">%d de intersecciones</item>
         <item quantity="other">%d intersecciones</item>
     </plurals>
 
     <plurals
         name="poi">
         <item quantity="one">1 punto</item>
+        <item quantity="many">%d de puntos</item>
         <item quantity="other">%d puntos</item>
     </plurals>
 
     <plurals
         name="station">
         <item quantity="one">1 estación</item>
+        <item quantity="many">%d de estaciones</item>
         <item quantity="other">%d estaciones</item>
     </plurals>
 
     <plurals
         name="street">
         <item quantity="one">1 calle</item>
+        <item quantity="many">%d de calles</item>
         <item quantity="other">%d calles</item>
     </plurals>
 
     <plurals
         name="turning">
         <item quantity="one">1 giro</item>
+        <item quantity="many">%d de giros</item>
         <item quantity="other">%d giros</item>
     </plurals>
 
     <plurals
         name="profile">
         <item quantity="one">1 perfil</item>
+        <item quantity="many">%d de perfiles</item>
         <item quantity="other">%d perfiles</item>
     </plurals>
 
     <plurals
         name="collection">
         <item quantity="one">1 colección</item>
+        <item quantity="many">%d de colecciones</item>
         <item quantity="other">%d colecciones</item>
     </plurals>
 
     <plurals
         name="collectionSelected">
         <item quantity="one">1 colección seleccionada</item>
+        <item quantity="many">%d de colecciones seleccionadas</item>
         <item quantity="other">%d colecciones seleccionadas</item>
     </plurals>
 
     <plurals
         name="pointProfile">
         <item quantity="one">1 perfil de puntos</item>
+        <item quantity="many">%d de perfiles de puntos</item>
         <item quantity="other">%d perfiles de puntos</item>
     </plurals>
 
     <plurals
         name="poiCategory">
         <item quantity="one">1 categoría de puntos</item>
+        <item quantity="many">%d de categorías de puntos</item>
         <item quantity="other">%d categorías de puntos</item>
     </plurals>
 
     <plurals
         name="poiCategorySelected">
         <item quantity="one">1 categoría de puntos seleccionada</item>
+        <item quantity="many">%d de categorías de puntos seleccionadas</item>
         <item quantity="other">%d categorías de puntos seleccionadas</item>
     </plurals>
 
     <plurals
         name="labelSomethingPinned">
         <item quantity="one">%1$s fijado</item>
+        <item quantity="many">%1$s fijados</item>
         <item quantity="other">%1$s fijados</item>
     </plurals>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -32,10 +32,10 @@
         La aplicación no recibirá actualizaciones de ubicación</string>
     <string name="messageLocationPermissionDeniedShort">Permiso de ubicación denegado</string>
     <string name="messagePostNotificationsPermissionDenied">La aplicación no recibirá actualizaciones de ubicación
-        porque no tiene permiso para enviarte notificaciones. Muchas de las funciones de WalkersGuide,
+        porque no tiene permiso para enviar notificaciones. Muchas de las funciones de WalkersGuide,
         como el seguimiento de ubicación y la grabación de rutas, se ejecutan en un servicio. Android requiere que este tipo de servicio
-        muestre una notificación si quiere ejecutarse de forma permanente.
-        Por eso, la aplicación solicita este permiso.</string>
+        muestre una notificación para ejecutarse de forma permanente.
+        La aplicación solicita este permiso por este motivo.</string>
     <string name="messagePostNotificationsPermissionDeniedShort">Permiso para enviar notificaciones denegado.</string>
 
     <!-- location provider disabled -->
@@ -54,8 +54,8 @@
 
     <!-- TrackingMode hints -->
     <string name="wgTrackingModeHintOff">Seguimiento desactivado</string>
-    <string name="wgTrackingModeHintDistance">Los puntos y rutas se anuncian cuando pasas cerca de ellos.</string>
-    <string name="wgTrackingModeHintBearing">Gira lentamente y escucha los puntos y rutas que están frente a ti.</string>
+    <string name="wgTrackingModeHintDistance">Los puntos y rutas se anuncian al pasar cerca de ellos.</string>
+    <string name="wgTrackingModeHintBearing">Gira lentamente y escucha los puntos y rutas que están en frente.</string>
 
 
     <!--
@@ -96,7 +96,7 @@
     <string name="labelGPSAccuracy">Precisión</string>
     <string name="labelGPSMslAltitude">Elevación</string>
     <string name="labelGPSEllipsoidAltitude">Elevación (aprox.)</string>
-    <string name="labelGPSBearing">Rumbo</string>
+    <string name="labelGPSBearing">Orientación</string>
     <string name="labelGPSSpeed">Velocidad</string>
     <string name="labelGPSTime">Última posición a las</string>
 
@@ -157,7 +157,7 @@
     <string name="pointSelectFromEnterAddress">Introducir dirección</string>
     <string name="pointSelectFromEnterCoordinates">Introducir coordenadas</string>
     <string name="pointSelectFromCollections">Colecciones</string>
-    <string name="pointSelectFromPOI">Seleccionar desde puntos cercanos</string>
+    <string name="pointSelectFromPOI">Seleccionar entre puntos cercanos</string>
     <string name="pointSelectFromHistory">Historial</string>
     <string name="pointSelectFromCoordinatesLink">Importar desde enlace compartido</string>
 
@@ -182,10 +182,10 @@
     <string name="pointFromCoordinatesLinkDialogTitle">Introducir enlace de coordenadas:</string>
     <string name="editHintMapLinkURL">URL de Google Maps, Apple Maps u OSM</string>
     <string name="messageLinkUrlMissing">Falta la URL de coordenadas.</string>
-    <string name="messageAppleMapsUrlFormatUnknown">No se pudo extraer la latitud y longitud. El formato de URL de coordenadas de Apple Maps es desconocido.</string>
-    <string name="messageGoogleMapsUrlFormatUnknown">No se pudo extraer la latitud y longitud. El formato de URL de coordenadas de Google Maps es desconocido.</string>
-    <string name="messageOsmOrgUrlFormatUnknown">No se pudo extraer la latitud y longitud. El formato de URL de coordenadas de OpenStreetMap es desconocido.</string>
-    <string name="messageOsmAndUrlFormatUnknown">No se pudo extraer la latitud y longitud. El formato de URL de coordenadas de OsmAnd es desconocido.</string>
+    <string name="messageAppleMapsUrlFormatUnknown">No se pudo extraer latitud y longitud. El formato de URL de coordenadas de Apple Maps es desconocido.</string>
+    <string name="messageGoogleMapsUrlFormatUnknown">No se pudo extraer latitud y longitud. El formato de URL de coordenadas de Google Maps es desconocido.</string>
+    <string name="messageOsmOrgUrlFormatUnknown">No se pudo extraer latitud y longitud. El formato de URL de coordenadas de OpenStreetMap es desconocido.</string>
+    <string name="messageOsmAndUrlFormatUnknown">No se pudo extraer latitud y longitud. El formato de URL de coordenadas de OsmAnd es desconocido.</string>
     <string name="messageLinkContainsInvalidCoordinates">Se encontraron coordenadas no válidas.</string>
     <string name="messageCouldNotResolveShortenedUrl">No se pudo resolver la URL acortada.</string>
     <string name="messageCouldNotObtainCoordinatesForOsmOrgNodeId">No se pudieron obtener las coordenadas para el ID de nodo introducido.</string>
@@ -236,7 +236,7 @@
     <string name="buttonAddPinnedProfile">Fijar perfil</string>
     <string name="groupNamePointsAndRoutes">Puntos y rutas</string>
     <string name="buttonAddPinnedPointOrRoute">Fijar punto o ruta</string>
-    <string name="labelNoPinnedObjectsHint">Aquí puedes añadir perfiles de puntos y colecciones, así como puntos y rutas para acceder rápidamente a ellos.</string>
+    <string name="labelNoPinnedObjectsHint">Aquí se pueden añadir perfiles de puntos y colecciones, así como puntos y rutas para acceder rápidamente.</string>
 
     <!-- track fragment -->
     <string name="fragmentTrackName">Seguir</string>
@@ -247,18 +247,18 @@
     <string name="spinnerTrackingModeCD">Modo de seguimiento</string>
     <string name="spinnerTrackingModePrompt">Seleccionar modo de seguimiento:</string>
     <string name="layoutTrackedProfile">Perfil seguido</string>
-    <string name="labelAnnouncementRadius">Dentro del radio de:</string>
-    <string name="spinnerAnnouncementRadiusPrompt">Anuncios dentro del radio de:</string>
+    <string name="labelAnnouncementRadius">Dentro de un radio de:</string>
+    <string name="spinnerAnnouncementRadiusPrompt">Anuncios dentro de un radio de:</string>
     <string name="buttonAddTrackedPoint">Añadir punto</string>
-    <string name="labelNoTrackedObjectsHint">Añade puntos que quieras seguir. Se anunciarán mediante voz periódicamente,
-        dependiendo del modo de seguimiento que hayas seleccionado arriba.</string>
+    <string name="labelNoTrackedObjectsHint">Añade puntos a seguir. Se anunciarán mediante voz periódicamente,
+        dependiendo del modo de seguimiento que se haya seleccionado arriba.</string>
 
     <!-- navigate fragment -->
     <string name="fragmentNavigateName">Navegar</string>
     <string name="labelRoutePosition">%1$d de %2$d\t(%3$d de %4$s, %5$d%%)</string>
-    <string name="labelRoutePositionCD">Instrucción %1$d de %2$d, %3$d de %4$s completado, %5$d%%</string>
+    <string name="labelRoutePositionCD">Instrucción %1$d de %2$d, %3$d de %4$s completada, %5$d%%</string>
     <string name="labelIntersectionStructureHeading">Estructura del cruce</string>
-    <string name="buttonPreviousRouteObject">Punto de ruta anterior</string>
+    <string name="buttonPreviousRouteObject">Anterior punto de ruta</string>
     <string name="buttonNextRouteObject">Siguiente punto de ruta</string>
     <string name="messageFirstSegment">Punto de inicio de la ruta</string>
     <!-- format example: 20 meters on main street, afterwards turn left -->
@@ -274,7 +274,7 @@
     <!-- record route fragment -->
     <string name="fragmentRecordRouteName">Grabar</string>
     <string name="menuItemCancelRouteRecording">Cancelar grabación</string>
-    <string name="cancelRouteRecordingDialogTitle">¿Realmente quieres cancelar esta grabación? La ruta ya grabada se perderá.</string>
+    <string name="cancelRouteRecordingDialogTitle">¿Realmente quieres cancelar esta grabación? La ruta grabada se perderá.</string>
     <string name="labelRecordedRouteStatus">Grabado</string>
     <string name="buttonStartRouteRecording">Iniciar grabación</string>
     <string name="buttonPauseRecording">Pausar</string>
@@ -316,7 +316,7 @@
     <string name="fragmentCollectionListName">Colecciones</string>
     <string name="fragmentCollectionListNameSelect">Seleccionar colección:</string>
     <string name="buttonAddCollection">Añadir colección</string>
-    <string name="labelEmptyCollectionList">Añade colecciones para ayudarte a gestionar tus puntos y rutas recopilados.</string>
+    <string name="labelEmptyCollectionList">Añade colecciones para ayudarte a gestionar tus puntos y rutas recopiladas.</string>
 
     <!-- create collections -->
     <string name="layoutCollectionName">Nombre de la colección:</string>
@@ -345,7 +345,7 @@
     <string name="fragmentPoiProfileListNameEmbedded">Cercanos</string>
     <string name="fragmentPoiProfileListNameSelect">Seleccionar perfil de puntos:</string>
     <string name="buttonAddPoiProfile">Añadir perfil de puntos</string>
-    <string name="labelEmptyPoiProfileList">Por favor, crea al menos un perfil de puntos para buscar puntos de interés cercanos.</string>
+    <string name="labelEmptyPoiProfileList">Crea al menos un perfil de puntos para buscar puntos de interés cercanos.</string>
 
     <!-- CreatePoiProfileDialog  -->
     <!-- Although in the apps code the following profile is referred to poi profile, in the ui it should use the more general "point profile" -->
@@ -576,7 +576,7 @@
     <string name="labelInterfaceSettingsHeader">Interfaz de usuario:</string>
     <string name="switchShowActionButton">Mostrar botón de acción</string>
     <string name="switchShowActionButtonHint">Alternativamente, realiza una pulsación larga para abrir el menú contextual.</string>
-    <string name="switchDisplayRemainsActive">La pantalla permanece activa mientras se usa la aplicación.</string>
+    <string name="switchDisplayRemainsActive">Mantener pantalla activa mientras se usa la aplicación.</string>
     <string name="switchDisplayRemainsActiveHint">Desactiva la función de bloqueo automático de pantalla durante la navegación.</string>
     <string name="switchPreferFusedLocationProviderInsteadOfNetworkProvider">Preferir el proveedor de ubicación fusionado para la determinación de ubicación.</string>
     <string name="switchPreferFusedLocationProviderInsteadOfNetworkProviderHint">Si está activado, obtienes ubicaciones más precisas especialmente dentro de edificios.

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -132,7 +132,7 @@
     <!-- options menu -->
     <string name="planRouteMenuItemSwap">Intercambiar inicio y destino</string>
     <string name="planRouteMenuItemExcludedWays">Vías excluidas</string>
-    <string name="planRouteMenuItemRoutingWayClasses">Ponderación de tipos de vía</string>
+    <string name="planRouteMenuItemRoutingWayClasses">Priorizar tipos de vía</string>
     <string name="planRouteMenuItemClear">Borrar puntos</string>
 
     <!-- ConfigureWayClassWeightsDialog -->
@@ -341,7 +341,7 @@
 
     <!-- PoiProfileListFragment -->
     <string name="fragmentPoiProfileListName">Perfiles de puntos</string>
-    <!-- the following is used as a toolbar title and is short for "Points nearby" -->
+    <!-- the following is used as a toolbar title and is short for "Points nearby / Puntos cercanos" -->
     <string name="fragmentPoiProfileListNameEmbedded">Cercanos</string>
     <string name="fragmentPoiProfileListNameSelect">Seleccionar perfil de puntos:</string>
     <string name="buttonAddPoiProfile">Añadir perfil de puntos</string>
@@ -389,7 +389,7 @@
     <!-- IntersectionStructureFragment -->
     <string name="fragmentIntersectionStructureName">Estructura del cruce</string>
     <string name="menuItemAnnounceWayAhead">Anunciar vías por delante</string>
-    <string name="labelPartOfPreviousRouteSegment">Segmento de ruta anterior</string>
+    <string name="labelPartOfPreviousRouteSegment">Anterior segmento de ruta</string>
     <string name="labelPartOfNextRouteSegment">Siguiente segmento de ruta</string>
 
     <!-- ExtendedObjectListFragment -->
@@ -405,7 +405,7 @@
     <!-- toolbar menu -->
     <string name="menuItemObjectTypeFilter">Filtrar por tipo</string>
     <string name="menuItemSortMethod">Ordenar por</string>
-    <string name="menuItemClearProfile">Vaciar perfil</string>
+    <string name="menuItemClearProfile">Borrar perfil</string>
     <!-- clear profile dialog -->
     <string name="clearProfileDialogTitle">¿Quieres eliminar todas las entradas del perfil \"%1$s\"?</string>
 
@@ -417,7 +417,7 @@
 
     <!-- PoiListFromServerFragment -->
     <string name="labelHeadingSecondLineRadius">Radio: %1$s</string>
-    <string name="labelMoreResults">Cargar más puntos</string>
+    <string name="labelMoreResults">Mostrar más puntos</string>
 
 
     <!--
@@ -504,7 +504,7 @@
     <string name="labelSegmentRouteDistance">Distancia</string>
     <!-- segment attributes -->
     <string name="labelSegmentFootwayAttributesHeading">Atributos</string>
-    <string name="labelSegmentBearing">Rumbo</string>
+    <string name="labelSegmentBearing">Orientación</string>
     <string name="labelSegmentFootwayDescription">Descripción</string>
     <string name="labelSegmentFootwaySidewalk">Acera</string>
     <string name="labelSegmentFootwaySurface">Superficie</string>
@@ -529,7 +529,7 @@
     <string name="menuItemSelectDepartureDateAndTime">Hora de salida</string>
     <string name="menuItemPublicTransportProvider">Proveedor de transporte público</string>
     <string name="menuItemSelectStation">Seleccionar estación</string>
-    <string name="labelNearby">Cercano</string>
+    <string name="labelNearby">Cerca de</string>
     <string name="labelNoPtStationsNearby">El proveedor de transporte seleccionado no encontró ninguna estación cercana.</string>
     <string name="labelSelectStation">Por favor, selecciona una estación.</string>
 
@@ -543,13 +543,13 @@
     <string name="selectDepartureDateAndTimeDialogTitle">Seleccionar fecha y hora de salida:</string>
 
     <!-- TripDetailsFragment -->
-    <string name="labelNoMoreStops">La línea llegó a su parada de destino.</string>
+    <string name="labelNoMoreStops">La línea ha llegado a su destino.</string>
 
     <!-- format departures -->
     <!-- format example: Tram 8 to main station -->
     <string name="labelLineAndDestination">%1$s a %2$s</string>
-    <string name="labelPredictedDeparture">Prevista</string>
-    <string name="labelPlannedDeparture">Planificada</string>
+    <string name="labelPredictedDeparture">Previsto</string>
+    <string name="labelPlannedDeparture">Planificado</string>
     <string name="labelFromPlatform">Desde andén %1$s</string>
 
 
@@ -567,9 +567,9 @@
     <string name="buttonServerMapNoSelection">Mapa: Ninguno seleccionado</string>
     <string name="switchPreferTranslatedStrings">Preferir traducciones</string>
     <string name="switchPreferTranslatedStringsHint">
-            Si la base de datos del mapa tiene varios idiomas almacenados para una entrada, este ajuste garantiza que la aplicación muestre
-            todo lo que esté disponible en el idioma de tu sistema o, como alternativa, en inglés.
-            Por ejemplo, el nombre de restaurantes o atracciones ocasionalmente está disponible como traducción al inglés.</string>
+            Si la base de datos del mapa tiene varios idiomas almacenados para una entrada, este ajuste garantiza que la aplicación muestra
+            todo lo que esté disponible en el idioma local o, sino, en inglés.
+            Por ejemplo, en ocasiones el nombre de restaurantes o atracciones están disponibles en varios idiomas.</string>
     <string name="labelPublicTransportSettingsHeader">Transporte público:</string>
     <string name="buttonPublicTransportProvider">Proveedor: %1$s</string>
     <string name="buttonPublicTransportProviderNoSelection">Proveedor: Ninguno seleccionado</string>
@@ -578,21 +578,21 @@
     <string name="switchShowActionButtonHint">Alternativamente, realiza una pulsación larga para abrir el menú contextual.</string>
     <string name="switchDisplayRemainsActive">Mantener pantalla activa mientras se usa la aplicación.</string>
     <string name="switchDisplayRemainsActiveHint">Desactiva la función de bloqueo automático de pantalla durante la navegación.</string>
-    <string name="switchPreferFusedLocationProviderInsteadOfNetworkProvider">Preferir el proveedor de ubicación fusionado para la determinación de ubicación.</string>
-    <string name="switchPreferFusedLocationProviderInsteadOfNetworkProviderHint">Si está activado, obtienes ubicaciones más precisas especialmente dentro de edificios.
+    <string name="switchPreferFusedLocationProviderInsteadOfNetworkProvider">Preferir el proveedor de ubicación combinada para determinar la ubicación.</string>
+    <string name="switchPreferFusedLocationProviderInsteadOfNetworkProviderHint">Si está activado se obtienen ubicaciones más precisas, especialmente dentro de edificios.
         Pero en algunos dispositivos puede causar problemas de precisión durante la navegación.
-        Si es así, deberías desactivar el proveedor de ubicación fusionado aquí.</string>
+        Si es así, deberías desactivar el proveedor de ubicación combinada aquí.</string>
     <string name="buttonShakeIntensity">Intensidad de agitación</string>
-    <string name="buttonShakeIntensityHint">Agita para actualizar el diálogo \"Dónde estoy\" y la pestaña \"Puntos\".</string>
+    <string name="buttonShakeIntensityHint">Agita el dispositivo para actualizar el diálogo \"Dónde estoy\" y la pestaña \"Puntos\".</string>
     <string name="labelTTSSettingsHeader">Texto a voz</string>
     <string name="switchAnnouncementsEnabled">Activar anuncios de voz</string>
     <string name="labelDistanceAnnouncementInterval">Intervalo de anuncio de distancia</string>
     <string name="labelDistanceAnnouncementIntervalUnit">metros</string>
-    <string name="buttonSpeechRate">Velocidad de voz</string>
+    <string name="buttonSpeechRate">Velocidad de la voz</string>
     <string name="switchKeepBluetoothHeadsetConnectionAlive">Mantener activa la conexión de auriculares Bluetooth</string>
     <string name="switchKeepBluetoothHeadsetConnectionAliveHint">
         Algunos auriculares Bluetooth entran en modo de suspensión después de un tiempo de inactividad y su posterior
-        activación produce un retraso notable. Entonces el inicio del
+        activación produce un retraso notable al reproducir sonido. El inicio del
         siguiente anuncio de voz puede quedar truncado.</string>
     <string name="labelImportAndExportSettingsHeader">Importar y exportar:</string>
     <string name="buttonImportSettings">Importar ajustes de la aplicación</string>
@@ -616,8 +616,8 @@
     <string name="selectShakeIntensityDialogTitle">Seleccionar intensidad:</string>
 
     <!-- SpeechRateDialog -->
-    <string name="buttonDecreaseSpeechRate">Reducir velocidad de voz</string>
-    <string name="buttonIncreaseSpeechRate">Aumentar velocidad de voz</string>
+    <string name="buttonDecreaseSpeechRate">Reducir velocidad de la voz</string>
+    <string name="buttonIncreaseSpeechRate">Aumentar velocidad de la voz</string>
 
     <!-- InfoFragment -->
     <string name="fragmentInfoName">Información</string>
@@ -637,7 +637,7 @@
     <string name="labelSelectedMapCreated">Creado</string>
     <!-- public transport data -->
     <string name="labelPublicTransportHeading">Datos de transporte público</string>
-    <string name="labelPublicTransportMessage">Los datos de transporte público son proporcionados por la biblioteca &lt;a href="%1$s"&gt;Public-transport-enabler&lt;/a&gt;.
+    <string name="labelPublicTransportMessage">Los datos de transporte público están proporcionados por la biblioteca &lt;a href="%1$s"&gt;Public-transport-enabler&lt;/a&gt;.
         Aquí puedes encontrar la &lt;a href="%2$s"&gt;lista de todos los proveedores compatibles&lt;/a&gt;.</string>
 
     <!-- SendFeedbackDialog -->
@@ -659,7 +659,7 @@
         <item>Fecha: 19 de noviembre de 2025</item>
         <item>- Categorías de puntos de interés actualizadas</item>
         <item>- Añadidas predicciones de salida en tiempo real a salidas y detalles de viaje</item>
-        <item>- Mejorado el rendimiento de actualización de brújula y ubicación</item>
+        <item>- Mejorado el rendimiento de actualización de la brújula y la ubicación</item>
         <item>- Actualizado el diseño de la flecha de dirección</item>
         <item>- Añadido soporte para Android 16</item>
     </string-array>
@@ -748,7 +748,7 @@
     <string name="contextMenuItemObjectWithIdStreetCourse">Recorrido de la calle</string>
     <string name="contextMenuItemObjectWithIdExcludeFromRouting">Excluido de la planificación de rutas</string>
     <string name="contextMenuItemObjectWithIdSimulateLocation">Ubicación simulada</string>
-    <string name="contextMenuItemObjectWithIdSimulateBearing">Rumbo simulado</string>
+    <string name="contextMenuItemObjectWithIdSimulateBearing">Orientación simulado</string>
     <string name="contextMenuItemObjectWithIdNavigateToThisPoint">Navegar a este punto</string>
     <string name="contextMenuItemObjectWithIdCollections">Añadir a colecciones</string>
     <string name="contextMenuItemObjectWithIdRoutePlanner">Planificador de rutas</string>
@@ -816,7 +816,7 @@
     <string name="labelIndexSelected">Instrucción actual</string>
 
     <!-- IntersectionScheme -->
-    <string name="labelIntersectionScheme">Esquema de la intersección</string>
+    <string name="labelIntersectionScheme">Esquema del cruce</string>
     <string name="labelIntersectionCenter">Centro del cruce</string>
 
     <!-- common context menu entries -->
@@ -836,7 +836,7 @@
     <string name="dialogClose">Cerrar</string>
     <string name="dialogYes">Sí</string>
     <string name="dialogNo">No</string>
-    <string name="dialogSelectAll">Todo</string>
+    <string name="dialogSelectAll">Todos</string>
     <string name="dialogAdd">Añadir</string>
     <string name="dialogAppInfo">Abrir página de información de la aplicación</string>
     <string name="dialogClear">Borrar</string>
@@ -860,7 +860,7 @@
     <string name="viewClassNameTab">Pestaña</string>
     <string name="messagePleaseWait">Por favor, espera…</string>
     <string name="messageNameIsMissing">Por favor, introduce un nombre.</string>
-    <string name="messageRenameFailed">El renombrado falló.</string>
+    <string name="messageRenameFailed">Renombrado fallido.</string>
     <string name="messageSetUserAnnotationFailed">No se pudo guardar la anotación.</string>
 
 
@@ -895,7 +895,7 @@
     <string name="pedestrianCrossingDetailsCrossingBarrierYes">Barrera</string>
     <string name="pedestrianCrossingDetailsKerbNo">Sin bordillo</string>
     <string name="pedestrianCrossingDetailsSoundYes">Sonido</string>
-    <string name="pedestrianCrossingDetailsTactilePavingYes">Pavimento táctil</string>
+    <string name="pedestrianCrossingDetailsTactilePavingYes">Superficie podotáctil</string>
     <!-- CrossingBarrier -->
     <string name="crossingBarrierFull">Completa</string>
     <string name="crossingBarrierHalf">Media</string>
@@ -952,9 +952,9 @@
     <string name="directionStraightAhead">Todo recto</string>
     <string name="directionRightSlightly">ligeramente a la derecha</string>
     <string name="directionRight">a la derecha</string>
-    <string name="directionRightStrongly">muy a la derecha</string>
+    <string name="directionRightStrongly">completamente a la derecha</string>
     <string name="directionBehind">Detrás de ti</string>
-    <string name="directionLeftStrongly">muy a la izquierda</string>
+    <string name="directionLeftStrongly">completamente a la izquierda</string>
     <string name="directionLeft">a la izquierda</string>
     <string name="directionLeftSlightly">ligeramente a la izquierda</string>
 
@@ -963,9 +963,9 @@
     <string name="instructionCross">Cruzar</string>
     <string name="instructionTurnRightSlightly">Girar ligeramente a la derecha</string>
     <string name="instructionTurnRight">Girar a la derecha</string>
-    <string name="instructionTurnRightStrongly">Girar muy a la derecha</string>
+    <string name="instructionTurnRightStrongly">Girar completamente a la derecha</string>
     <string name="instructionTurnRound">Dar la vuelta</string>
-    <string name="instructionTurnLeftStrongly">Girar muy a la izquierda</string>
+    <string name="instructionTurnLeftStrongly">Girar completamente a la izquierda</string>
     <string name="instructionTurnLeft">Girar a la izquierda</string>
     <string name="instructionTurnLeftSlightly">Girar ligeramente a la izquierda</string>
 
@@ -1005,7 +1005,7 @@
     <string name="collectionNameFavorites">Favoritos</string>
 
     <!-- ObjectTypeFilter -->
-    <string name="objectTypeFilterAll">Todo</string>
+    <string name="objectTypeFilterAll">Todos</string>
     <string name="objectTypeFilterPoints">Puntos</string>
     <string name="objectTypeFilterRoutes">Rutas</string>
     <string name="objectTypeFilterSegments">Caminos</string>
@@ -1166,7 +1166,7 @@
     <string name="bearingSensorAccuracyUnknown">Desconocida</string>
 
     <!-- ShakeIntensity -->
-    <string name="shakeIntensityDisabled">Desactivado</string>
+    <string name="shakeIntensityDisabled">Desactivada</string>
     <string name="shakeIntensityVeryWeak">Muy débil</string>
     <string name="shakeIntensityWeak">Débil</string>
     <string name="shakeIntensityMedium">Media</string>
@@ -1192,16 +1192,16 @@
 
     <!-- walkersguide server -->
     <string name="errorWgReqBadRequest">Servidor WalkersGuide: Parámetros de solicitud no válidos.</string>
-    <string name="errorWgReqRequestInProgress">Una solicitud anterior aún se está procesando. Por favor, inténtalo más tarde.</string>
+    <string name="errorWgReqRequestInProgress">Una solicitud anterior aún se está procesando. Por favor, inténtalo de nuevo más tarde.</string>
     <string name="errorWgReqInternalServerError">Error interno del servidor.</string>
-    <string name="errorWgReqServiceUnavailableOrBusy">El servidor está ocupado. Por favor, inténtalo más tarde.</string>
+    <string name="errorWgReqServiceUnavailableOrBusy">El servidor está ocupado. Por favor, inténtalo de nuevo más tarde.</string>
     <string name="errorWgReqNoPOITagsSelected">No hay categorías de puntos seleccionadas.</string>
     <string name="errorWgReqMapLoadingFailed">El mapa seleccionado no está disponible en el servidor o está desactualizado.</string>
     <string name="errorWgReqWrongMapSelected">La ubicación indicada está fuera del mapa seleccionado.</string>
     <string name="errorWgReqMapOutdated">El mapa seleccionado no ofrece esta función.</string>
     <string name="errorWgReqStartOrDestinationMissing">Falta el punto de inicio o destino.</string>
     <string name="errorWgReqStartAndDestinationTooFarAway">La distancia entre los puntos de inicio y destino es demasiado grande. Por favor, incluye al menos un punto intermedio.</string>
-    <string name="errorWgReqTooManyWayClassesIgnored">Has excluido demasiadas clases de vías del cálculo de rutas.</string>
+    <string name="errorWgReqTooManyWayClassesIgnored">Has excluido demasiados tipos de caminos del cálculo de rutas.</string>
     <string name="errorWgReqNoRouteBetweenStartAndDestination">El servidor no puede encontrar una ruta entre el inicio y el destino indicados.</string>
 
     <!-- app errorWgReqs -->
@@ -1213,10 +1213,10 @@
     <!-- route -->
     <string name="errorWgReqNoRouteCreated">No se ha creado ninguna ruta.</string>
     <string name="errorWgReqNoRouteSelected">No hay ninguna ruta seleccionada.</string>
-    <string name="errorWgReqRouteParsing">Error al analizar la ruta.</string>
+    <string name="errorWgReqRouteParsing">Error al procesar la ruta.</string>
     <!-- status -->
     <string name="errorWgReqNoServerURL">URL del servidor vacía o no válida.</string>
-    <string name="errorWgReqAPIClientOutdated">La versión de la API de esta aplicación es demasiado antigua para el servidor seleccionado. Por favor, busca actualizaciones de la aplicación en walkersguide.org o en Google Play Store.</string>
+    <string name="errorWgReqAPIClientOutdated">La versión de la API de esta aplicación es demasiado antigua para el servidor seleccionado. Por favor, busca actualizaciones en walkersguide.org o en la tienda Google Play.</string>
     <string name="errorWgReqAPIServerOutdated">La versión de la API del servidor de mapas seleccionado ya no es compatible con esta aplicación.</string>
     <string name="errorWgReqNoMapList">El servidor no ofrece ningún mapa.</string>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -42,13 +42,13 @@
     <string name="messageLocationProviderDisabledShort">Servicio de ubicación desactivado</string>
 
     <!-- RouteRecordingState -->
-    <string name="wgRouteRecordingStateOff">Apagado</string>
+    <string name="wgRouteRecordingStateOff">Desactivado</string>
     <string name="wgRouteRecordingStatePaused">Pausado</string>
     <string name="wgRouteRecordingStateRunning">Encendido</string>
     <string name="messageRouteRecordingPaused">Grabación de ruta pausada</string>
 
     <!-- TrackingMode -->
-    <string name="wgTrackingModeOff">Apagado</string>
+    <string name="wgTrackingModeOff">Desactivado</string>
     <string name="wgTrackingModeDistance">Distancia</string>
     <string name="wgTrackingModeBearing">Dirección de vista</string>
 
@@ -157,7 +157,7 @@
     <string name="pointSelectFromEnterAddress">Introducir dirección</string>
     <string name="pointSelectFromEnterCoordinates">Introducir coordenadas</string>
     <string name="pointSelectFromCollections">Colecciones</string>
-    <string name="pointSelectFromPOI">Seleccionar de puntos cercanos</string>
+    <string name="pointSelectFromPOI">Seleccionar desde puntos cercanos</string>
     <string name="pointSelectFromHistory">Historial</string>
     <string name="pointSelectFromCoordinatesLink">Importar desde enlace compartido</string>
 
@@ -200,7 +200,7 @@
     <string name="labelName">Nombre</string>
     <string name="messageNameMissing">Por favor, introduce un nombre.</string>
     <!-- format example: Satellite singal: Accuracy at 15 meters, last fix at 15:03:59 -->
-    <string name="labelGPSSignal">Señal satelital:\nPrecisión de %1$s, %2$s</string>
+    <string name="labelGPSSignal">Señal de satélite:\nPrecisión de %1$s, %2$s</string>
     <string name="messageSearchLocationInProgress">Se está obteniendo la ubicación actual, por favor espera…</string>
     <string name="messageCurrentLocationAddedToPinnedObjectsWithIdSuccessful">La ubicación actual se fijó correctamente.</string>
     <string name="messageCurrentLocationAddedToTrackedObjectsWithIdSuccessful">Se inició el seguimiento de la ubicación actual.</string>
@@ -232,7 +232,6 @@
     <string name="menuItemClearPinnedObjectsOnlyProfiles">Solo perfiles</string>
     <string name="menuItemClearPinnedObjectsOnlyPointsAndRoutes">Solo puntos y rutas</string>
     <string name="menuItemClearPinnedObjectsBoth">Borrar ambos</string>
-    <string name="labelSomethingPinned">%1$s fijado</string>
     <string name="groupNameProfiles">Perfiles</string>
     <string name="buttonAddPinnedProfile">Fijar perfil</string>
     <string name="groupNamePointsAndRoutes">Puntos y rutas</string>
@@ -288,9 +287,9 @@
     <string name="buttonFinishRecordingCD">Finalizar grabación</string>
     <string name="labelRecordedPointName">Punto %1$d</string>
     <string name="labelNoRecordedRoutes">Aún no se han grabado rutas.</string>
-    <string name="messageNoteRouteRecordingOnlyInForeground">Ten en cuenta que tu ruta solo se graba mientras la aplicación está en primer plano.
-        Cuando bloqueas la pantalla o pones WalkersGuide en segundo plano, la grabación de la ruta se pausa.</string>
-    <string name="messageRecordedRouteTooFewPoints">No se puede guardar la ruta grabada. Todavía contiene muy pocos puntos.</string>
+    <string name="messageNoteRouteRecordingOnlyInForeground">Ten en cuenta que la ruta solo se graba mientras la aplicación está en primer plano.
+        Si se bloquea la pantalla o WalkersGuide queda en segundo plano, la grabación de la ruta se pausa.</string>
+    <string name="messageRecordedRouteTooFewPoints">No se puede guardar la ruta grabada. Contiene demasiados pocos puntos.</string>
     <string name="messageRecordedRouteNameIsMissing">Por favor, introduce un nombre para la ruta grabada.</string>
     <string name="messageSaveRecordedRouteFailed">Error: No se puede guardar la ruta grabada.</string>
     <string name="messageSaveRecordedRouteSuccessful">La ruta se guardó correctamente.</string>
@@ -405,7 +404,7 @@
     <string name="labelHeadingSecondLineSortMethod">Ordenado por %1$s</string>
     <!-- toolbar menu -->
     <string name="menuItemObjectTypeFilter">Filtrar por tipo</string>
-    <string name="menuItemSortMethod">Método de ordenación</string>
+    <string name="menuItemSortMethod">Ordenar por</string>
     <string name="menuItemClearProfile">Vaciar perfil</string>
     <!-- clear profile dialog -->
     <string name="clearProfileDialogTitle">¿Quieres eliminar todas las entradas del perfil \"%1$s\"?</string>
@@ -414,7 +413,7 @@
     <string name="selectObjectTypeFilterDialogTitle">¿Qué objetos quieres ver?</string>
 
     <!-- SelectSortMethodDialog -->
-    <string name="selectSortMethodDialogTitle">Seleccionar método de ordenación:</string>
+    <string name="selectSortMethodDialogTitle">Ordenar por:</string>
 
     <!-- PoiListFromServerFragment -->
     <string name="labelHeadingSecondLineRadius">Radio: %1$s</string>
@@ -802,7 +801,7 @@
 
 
     <!--
-         other dialogs and layouts
+         many dialogs and layouts
     -->
 
     <!-- CreateOrSelectCollectionDialog -->
@@ -852,7 +851,7 @@
     <string name="dialogShare">Compartir</string>
     <string name="dialogTest">Probar</string>
 
-    <!-- other common labels and messages -->
+    <!-- many common labels and messages -->
     <string name="fillingWordAnd">y</string>
     <string name="fillingWordCustom">personalizado</string>
     <string name="fillingWordHas">tiene</string>
@@ -888,8 +887,6 @@
     <!-- intersection point -->
     <!-- format example: Intersection with 4 streets  -->
     <string name="intersectionNumberOfStreets">Cruce con %1$s</string>
-    <!-- format example: 2 crossings nearby -->
-    <string name="intersectionNumberOfCrossingsNearby">%1$s cercanos</string>
 
     <!-- PedestrianCrossing -->
     <!-- details in toString -->
@@ -1031,14 +1028,14 @@
     <string name="poiCategoryFood">Comida y bebida</string>
     <string name="poiCategoryAccommodation">Hoteles y alojamientos</string>
     <string name="poiCategoryTourism">Lugares de interés e información turística</string>
-    <string name="poiCategoryEntertainment">Entretenimiento:\n  Cines, teatros, bares, pubs, …</string>
+    <string name="poiCategoryEntertainment">Entretenimiento:\n  Cines, teatros, bares, pubs…</string>
     <string name="poiCategoryFinance">Finanzas</string>
     <string name="poiCategoryPostBox">Correos y paquetería, buzones</string>
     <string name="poiCategoryShop">Compras</string>
     <string name="poiCategoryEducation">Educación e investigación</string>
-    <string name="poiCategoryHealth">Salud:\n  Médicos, farmacias, hospitales, …</string>
-    <string name="poiCategorySport">Deportes y recreación:\n  Instalaciones deportivas, parques infantiles, parques, …</string>
-    <string name="poiCategoryPublicService">Servicios públicos:\n  Policía, bomberos, oficinas municipales, …</string>
+    <string name="poiCategoryHealth">Salud:\n  Médicos, farmacias, hospitales…</string>
+    <string name="poiCategorySport">Deportes y recreación:\n  Instalaciones deportivas, parques infantiles, parques…</string>
+    <string name="poiCategoryPublicService">Servicios públicos:\n  Policía, bomberos, oficinas municipales…</string>
     <string name="poiCategoryOtherService">Todos los demás servicios</string>
     <string name="poiCategoryElevator">Ascensores</string>
     <string name="poiCategorySanitary">Aseos y duchas</string>
@@ -1241,7 +1238,7 @@
     <string name="errorAddrReqNoCoordinatesForAddress">No se encontraron coordenadas para esta dirección.</string>
     <string name="errorAddrReqNoAddressForCoordinates">No se encontró ninguna dirección para estas coordenadas.</string>
 
-    <!-- other errors -->
+    <!-- many errors -->
     <string name="errorSavePointFailed">Error al crear el punto.</string>
     <string name="errorNoHomeAddressSet">Aún no has seleccionado tu dirección de casa. Puedes hacerlo en la configuración de la aplicación.</string>
     <string name="errorNoLocationFound">No hay ubicación disponible.</string>
@@ -1372,6 +1369,13 @@
         <item quantity="other">%d cruces</item>
     </plurals>
 
+    <!-- format example: 2 crossings nearby -->
+    <plurals
+        name="intersectionNumberOfCrossingsNearby">
+        <item quantity="one">1 cruce cercano</item>
+        <item quantity="other">%d cruces cercanos</item>
+    </plurals>
+
     <plurals
         name="entrance">
         <item quantity="one">1 entrada</item>
@@ -1442,6 +1446,12 @@
         name="poiCategorySelected">
         <item quantity="one">1 categoría de puntos seleccionada</item>
         <item quantity="other">%d categorías de puntos seleccionadas</item>
+    </plurals>
+
+    <plurals
+        name="labelSomethingPinned">
+        <item quantity="one">%1$s fijado</item>
+        <item quantity="other">%1$s fijados</item>
     </plurals>
 
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -222,7 +222,6 @@
     <string name="menuItemClearPinnedObjectsOnlyProfiles">Тільки профілі</string>
     <string name="menuItemClearPinnedObjectsOnlyPointsAndRoutes">Тільки точки і маршрути</string>
     <string name="menuItemClearPinnedObjectsBoth">Скинути все</string>
-    <string name="labelSomethingPinned">%1$s закріплено</string>
     <string name="groupNameProfiles">Профілі</string>
     <string name="buttonAddPinnedProfile">Закріпити профіль</string>
     <string name="groupNamePointsAndRoutes">Точки та маршрути</string>
@@ -857,7 +856,6 @@
 
     <!-- intersection point -->
 <string name="intersectionNumberOfStreets">Перехрестя, має %1$s</string>
-<string name="intersectionNumberOfCrossingsNearby">%1$s поруч</string>
 
     <!-- PedestrianCrossing -->
     <!-- details in toString -->
@@ -1356,6 +1354,15 @@
         <item quantity="other">%d переходів</item>
     </plurals>
 
+    <!-- format example: 2 crossings nearby -->
+    <plurals
+        name="intersectionNumberOfCrossingsNearby">
+        <item quantity="one">%d перехід поруч</item>
+        <item quantity="few">%d переходи поруч</item>
+        <item quantity="many">%d переходів поруч</item>
+        <item quantity="other">%d переходів поруч</item>
+    </plurals>
+
     <plurals
         name="entrance">
         <item quantity="one">%d вхід</item>
@@ -1450,6 +1457,14 @@
         <item quantity="few">%d категорії точок вибрано</item>
         <item quantity="many">%d категорій точок вибрано</item>
         <item quantity="other">%d категорій точок вибрано</item>
+    </plurals>
+
+    <plurals
+        name="labelSomethingPinned">
+        <item quantity="one">%1$s закріплено</item>
+        <item quantity="few">%1$s закріплено</item>
+        <item quantity="many">%1$s закріплено</item>
+        <item quantity="other">%1$s закріплено</item>
     </plurals>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -231,7 +231,6 @@
     <string name="menuItemClearPinnedObjectsOnlyProfiles">Only profiles</string>
     <string name="menuItemClearPinnedObjectsOnlyPointsAndRoutes">Only points and routes</string>
     <string name="menuItemClearPinnedObjectsBoth">Clear both</string>
-    <string name="labelSomethingPinned">%1$s pinned</string>
     <string name="groupNameProfiles">Profiles</string>
     <string name="buttonAddPinnedProfile">Pin profile</string>
     <string name="groupNamePointsAndRoutes">Points and routes</string>
@@ -887,8 +886,6 @@
     <!-- intersection point -->
     <!-- format example: Intersection with 4 streets  -->
     <string name="intersectionNumberOfStreets">Intersection with %1$s</string>
-    <!-- format example: 2 crossings nearby -->
-    <string name="intersectionNumberOfCrossingsNearby">%1$s nearby</string>
 
     <!-- PedestrianCrossing -->
     <!-- details in toString -->
@@ -1370,6 +1367,13 @@
         <item quantity="other">%d crossings</item>
     </plurals>
 
+    <!-- format example: 2 crossings nearby -->
+    <plurals
+        name="intersectionNumberOfCrossingsNearby">
+        <item quantity="one">1 crossing nearby</item>
+        <item quantity="other">%d crossings nearby</item>
+    </plurals>
+
     <plurals
         name="entrance">
         <item quantity="one">1 entrance</item>
@@ -1440,6 +1444,12 @@
         name="poiCategorySelected">
         <item quantity="one">1 point category selected</item>
         <item quantity="other">%d point categories selected</item>
+    </plurals>
+
+    <plurals
+        name="labelSomethingPinned">
+        <item quantity="one">%1$s pinned</item>
+        <item quantity="other">%1$s pinned</item>
     </plurals>
 
 </resources>


### PR DESCRIPTION
Hey! I finished reviewing the translations for the app. Most of them were perfectly fine so I just tweaked some minor things. 

The way some texts were designed was not compatible with the Spanish language. For example, this string was created using a plural and a normal string ((2 points) pinned). However, in Spanish both "points" and "pinned" change in the plural form. To keep the option to pin multiple types of things, I defined "pinned" as a plural, but had to create a new function to retrieve plurals without formatting them. The case "2 crossings nearby" also changes, but since the word "nearby" is only used once, I defined the whole string as a new plural. Feel free to modify these changes as you prefer.

There are a couple of texts I couldn't find in the app. Not very important but may be wrong.
**- Line 397 in EN Strings.xml:** I'm not sure how to translate "from" depending on what comes next.
**- Line 401 in EN Strings.xml:** Is filter a noun or a verb?